### PR TITLE
Update for py4j-0.10.6

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,8 +1,8 @@
 {% set name = "py4j" %}
-{% set version = "0.10.5" %}
+{% set version = "0.10.6" %}
 {% set bundle = "zip" %}
 {% set hash_type = "sha256" %}
-{% set hash_val = "86f78acff01b73fd8d2adaa713b608ddad6c9a0a00aaa71d6087827a713eed00" %}
+{% set hash_val = "d3e7ac7c2171c290eba87e70aa5095b7eb6d6ad34789c007c88d550d9f575083" %}
 {% set build = 0 %}
 
 package:


### PR DESCRIPTION
Needed for pyspark 2.2.0.